### PR TITLE
Update en_US.go to fix gotext error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,10 @@ module github.com/DataDrake/cli-ng
 require (
 	github.com/golang/lint v0.0.0-20181217174547-8f45f776aaf1 // indirect
 	github.com/kisielk/gotool v1.0.0
-	github.com/leonelquinteros/gotext v1.3.1
+	github.com/leonelquinteros/gotext v1.4.0
 	github.com/mattn/kinako v0.0.0-20170717041458-332c0a7e205a
 	golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1 // indirect
 	golang.org/x/tools v0.0.0-20181221235234-d00ac6d27372 // indirect
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/golang/lint v0.0.0-20181217174547-8f45f776aaf1/go.mod h1:tluoj9z5200j
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/leonelquinteros/gotext v1.3.1 h1:K27CGKi2OOo2dFa7B5ZjRrUQm1v/kUT7hBTM2Ep4NhY=
 github.com/leonelquinteros/gotext v1.3.1/go.mod h1:wC3peUDQHST5UU2RQefLkMIN1MWLvkCpmd59+et4jk4=
+github.com/leonelquinteros/gotext v1.4.0 h1:2NHPCto5IoMXbrT0bldPrxj0qM5asOCwtb1aUQZ1tys=
+github.com/leonelquinteros/gotext v1.4.0/go.mod h1:yZGXREmoGTtBvZHNcc+Yfug49G/2spuF/i/Qlsvz1Us=
 github.com/mattn/kinako v0.0.0-20170717041458-332c0a7e205a h1:0Q3H0YXzMHiciXtRcM+j0jiCe8WKPQHoRgQiRTnfcLY=
 github.com/mattn/kinako v0.0.0-20170717041458-332c0a7e205a/go.mod h1:CdTTBOYzS5E4mWS1N8NWP6AHI19MP0A2B18n3hLzRMk=
 golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1 h1:rJm0LuqUjoDhSk2zO9ISMSToQxGz7Os2jRiOL8AWu4c=

--- a/translate/en_US.go
+++ b/translate/en_US.go
@@ -26,6 +26,6 @@ msgstr "GLOBAL FLAGS:"
 
 func init() {
 	po := new(gotext.Po)
-	po.Parse(enUS)
+	po.Parse([]byte(enUS))
 	Internal["en_US"] = po
 }


### PR DESCRIPTION
Hi Bryan, 

When pulling `cli-ng` as a module dependency, the latest version of `gotext` is used when found in another application dependency regardless of the version used by `cli-ng`. This results in the error shown below. 
```
/src/github.com/DataDrake/cli-ng/translate/en_US.go:29:10: cannot use enUS (type string) as type []byte in argument to po.Parse
```
In one of the recent updates to `gotext` the parse command was updated from accepting a string to a byte array. (Shown below)
``` go
// gotext code
// Parse loads the translations specified in the provided string (str)
func (po *Po) Parse(buf []byte) {
	// Lock while parsing
	po.Lock()

	// Init storage
	if po.translations == nil {
		po.translations = make(map[string]*Translation)
		po.contexts = make(map[string]map[string]*Translation)
	}
```
This pull request converts the existing string used by `en_US.go` to a byte array before parsing it. I tested this pull request recompiling cli-ng and importing it as a module dependency from my fork. Making this modification fixed the previous error for me.